### PR TITLE
package.json files are 2 space indentation, not 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function(packageFile) {
   if(pkg.dependencies) {
     pkg.bundledDependencies = Object.keys(pkg.dependencies);
 
-    fs.writeFile(packageFile, JSON.stringify(pkg, null, 4), function(error) {
+    fs.writeFile(packageFile, JSON.stringify(pkg, null, 2), function(error) {
       if (error) {
         throw error;
       }


### PR DESCRIPTION
This won't cause unnecessary changes to the package.json when either this script is run or you run npm --save after running this script.
